### PR TITLE
Update position of sublabels on register.html

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,7 +69,7 @@ body {
 .sublabel {
     position: absolute;
     top: 3.5rem;
-    left: 3rem;
+    left: 4.5rem;
 }
 
 /* Buttons */


### PR DESCRIPTION
Move registration form sublabels to the right to accommodate prefix
icons beside input fields