### PR TITLE
Update layout of search filters section

### DIFF
--- a/templates/terms.html
+++ b/templates/terms.html
@@ -45,7 +45,6 @@
         /><span id="clear">x</span>
             </div>
 				<!--Select Game Dropdown-->
-                <h3 class="heading uppercase center-align">Search By Game</h3>
                 <div class="input-field">
 					<select id="game-filter" name="game-filter" class="game-filter">
             <option value="" disabled selected>Choose game</option>
@@ -53,7 +52,7 @@
             <option value="{{ game.game_name }}">{{ game.game_name }}</option>
             {% endfor %}
           </select>
-					<!--<label for="game-filter">Or filter by game</label>-->
+					<label for="game-filter">Filter by game</label>
 				</div>
 				<div class="padded-btns center-align hide-on-large-only">
 					<!--Alphabetical Sidebar-->
@@ -69,7 +68,7 @@
 				
 				<div class="col l8 offset-l2 hide-on-med-and-down show-on-large center-align">
 					<!--Alphabetical Buttons Acting As Filters-->
-                    <h3 class="heading uppercase center-align">Filter alphabetically</h3>
+                    <span class="heading center-align block">Filter alphabetically</span>
                     <button
             class="alpha-btns blue-btn blue-background off-white alphabet-letter text-shadow"
           >


### PR DESCRIPTION
- Remove heading elements to lessen space taken up by sticky section on mobile
- Replace "Filter Alphabetically" heading with a span with the same text