### PR TITLE
Reduce img-logo height

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -387,7 +387,7 @@ textarea.materialize-textarea:not(.browser-default):focus:not([readonly]) {
 }
 
 .img-logo {
-  height: 5.6rem;
+  height: 5rem;
 }
 
 


### PR DESCRIPTION
- Fix display of navbar in Firefox by reducing height of img-logo element