### PR TITLE
Fix select dropdown issue on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ In order to deploy this project to Heroku:
 
 [Spinner button on Contact Us page](https://www.w3schools.com/howto/howto_css_loading_buttons.asp)
 
+[Fix iOS issue with Materialize select dropdowns](https://github.com/Dogfalo/materialize/issues/4983)
+
 ### Media
 [Logo Image](https://cdn.pixabay.com/photo/2017/09/08/00/05/icon-2727224_960_720.png)
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -261,8 +261,20 @@ textarea.materialize-textarea:not(.browser-default):focus:not([readonly]) {
   position: relative;
 }
 
-.select-dropdown li {
-    padding: 1rem;
+/* Select Wrappers */
+/* Fixes select issue on iOS. Credit: https://github.com/Dogfalo/materialize/issues/4983 */
+.select-wrapper {
+	position: relative;
+}
+.select-wrapper select {
+	display: block;
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	z-index: 10;
+	opacity: 0;
 }
 
 #clear {

--- a/testing.md
+++ b/testing.md
@@ -242,9 +242,12 @@ In the end, I decided that a more elegant approach would be to include a Floatin
 ### Submit Definition
 Users were able to submit definitions without being able to select a game from the dropdown menu. Adding required to the select element simply resulted in the form not submitting, but there was no indication as to why the form would not submit. As a result, asterisks were added to the required form elements and the button's default behaviour was set to be disabled (as is the case on the registration page). When the user completes all necessary fields, including selecting an option from the game dropdown, a JavaScript function enables the button so that the definition can be submitted.
 
+#### Dropdown Selection On iPhone
+Using Materialize, there is currently a bug on iOS when using the dropdown selection elements (searching for a game, for example). After selecting an option from the list, the wrong option is displayed, and used, as a filter. This issue is not unique to Esports Dictionary, however, and has been reported on a number of sites. The behaviour was replicated on the [Materialize site](https://materializecss.com/select.html) when testing the demo Select element.
+
+A workaround was [posted by alexdpunkt](https://github.com/Dogfalo/materialize/issues/4983) and has been implemented in this project.
+
 ### Any known issues?
 #### Search Terms Game Dropdown
 While the text searchbar is cleared if any other filter is applied, the game dropdown remains set to the last selected filter. Attempts to update the class of the first item to selected or setting the value of the option element have proven fruitless so far. 
 
-#### Dropdown Selection On iPhone
-Using Materialize, there is currently a bug on iOS when using the dropdown selection elements (searching for a game, for example). After selecting an option from the list, the wrong option is displayed, and used, as a filter. This issue is not unique to Esports Dictionary, however, and has been reported on a number of sites. The behaviour was replicated on the [Materialize site](https://materializecss.com/select.html) when testing the demo Select element.


### PR DESCRIPTION
- Force native select field to overlay material select to fix issue on iOS where
the incorrect option would be chosen after the user made their selection