### PR TITLE
Fix bug of text overflowing button on 404 page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -375,6 +375,7 @@ textarea.materialize-textarea:not(.browser-default):focus:not([readonly]) {
 .homepage-button {
   cursor: pointer;
   width: 100%;
+  height: 100%;
 }
 
 


### PR DESCRIPTION
- Add height: 100% to homepage-button class to fix issue of text appearing
outside of button